### PR TITLE
Add -defer argument to read_verilog

### DIFF
--- a/syn/tcl/yosys_run_synth.tcl
+++ b/syn/tcl/yosys_run_synth.tcl
@@ -14,7 +14,7 @@ if { $lr_synth_timing_run } {
   write_sdc_out $lr_synth_sdc_file_in $lr_synth_sdc_file_out
 }
 
-yosys "read_verilog -sv ./rtl/prim_clock_gating.v $lr_synth_out_dir/generated/*.v"
+yosys "read_verilog -defer -sv ./rtl/prim_clock_gating.v $lr_synth_out_dir/generated/*.v"
 
 if { $lr_synth_ibex_branch_target_alu } {
   yosys "chparam -set BranchTargetALU 1 ibex_core"


### PR DESCRIPTION
Without this argument, Yosys tries to compile the Verilog sources as
they are read without knowing which files are actually used. This means
also part of the tracer infrastucture (ibex_core_tracing.v) is compiled
which is expected to fail and then aborts the synthesis process.